### PR TITLE
Make positional only args kwargs or positional

### DIFF
--- a/fast_query_parsers.pyi
+++ b/fast_query_parsers.pyi
@@ -12,7 +12,7 @@ Returns:
     A list of string/string tuples.
 """
 
-def parse_url_encoded_dict(qs: bytes, parse_numbers: bool) -> dict[str, Any]: ...
+def parse_url_encoded_dict(qs: bytes, parse_numbers: bool = False) -> dict[str, Any]: ...
 
 """Parse a query string into a dictionary of values.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@ pub use query_string::{parse_query_string as parse_qs, parse_query_string_to_jso
 
 // parse query string into a list of tuples.
 #[pyfunction]
-#[pyo3(text_signature = "(qs, separator, /)")]
+#[pyo3(text_signature = "(qs, separator)")]
 fn parse_query_string(qs: &[u8], separator: char) -> PyResult<Vec<(String, String)>> {
     Ok(parse_qs(qs, separator))
 }
 
 // parse query string into a python object.
 #[pyfunction]
-#[pyo3(signature = (qs, parse_numbers=true, /),text_signature = "(qs, parse_numbers=true, /)")]
+#[pyo3(signature = (qs, parse_numbers=true),text_signature = "(qs, parse_numbers=true)")]
 fn parse_url_encoded_dict(py: Python, qs: &[u8], parse_numbers: bool) -> PyResult<PyObject> {
     Ok(pythonize(py, &parse_query_string_to_json(qs, parse_numbers)).unwrap())
 }

--- a/tests/test_parse_qs.py
+++ b/tests/test_parse_qs.py
@@ -53,3 +53,16 @@ def test_parse_urlencoded_defaults_parse_numbers_true() -> None:
         "polluting": False,
         "json": None,
     }
+
+
+def test_parse_urlencoded_kwargs() -> None:
+    result = parse_url_encoded_dict(qs=encoded, parse_numbers=True)
+    assert result == {
+        "value": [10, 12],
+        "veggies": ["tomato", "potato", "aubergine"],
+        "nested": {"some_key": "some_value"},
+        "calories": 122.53,
+        "healthy": True,
+        "polluting": False,
+        "json": None,
+    }

--- a/tests/test_parse_qsl.py
+++ b/tests/test_parse_qsl.py
@@ -77,3 +77,7 @@ def test_parses_non_ascii_text() -> None:
     assert parse_query_string("arabic_text=اختبار اللغة العربية".encode(), "&") == [
         ("arabic_text", "اختبار اللغة العربية")
     ]
+
+
+def test_kwargs() -> None:
+    assert parse_query_string(qs=b"foo=bar", separator="&") == [("foo", "bar")]


### PR DESCRIPTION
Makes the positional only args of `parse_query_string` and `parse_url_encoded_dict` positional or keyword args.

[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
